### PR TITLE
Remove double «and

### DIFF
--- a/testing.md
+++ b/testing.md
@@ -90,7 +90,7 @@ public boolean isAvailable() {
 
 ---
 
-### An automated program that describes intent and and verifies behaviour repeatably.
+### An automated program that describes intent and verifies behaviour repeatably.
 
 ---
 


### PR DESCRIPTION
## Removed a double `and` on the «Beyonce» slide

![Giphy](http://media2.giphy.com/media/OGS0lT6ctBj6o/giphy.gif)
